### PR TITLE
upgrade rxdart version to 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+
+## 0.1.1
+
+* Bumped `rxdart` to `^0.28.0`.
+
 ## 0.1.0
 
 * Write README.md

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -342,10 +342,10 @@ packages:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -225,7 +225,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   leancode_lint:
     dependency: "direct dev"
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_hooks: ^0.20.1
   leancode_forms:
     path: ..
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
 
 dev_dependencies:
   bloc_test: ^9.1.4

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: leancode_forms_example
 description: A new Flutter project.
 publish_to: "none"
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=3.1.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
 
 dev_dependencies:
   bloc_test: ^9.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: leancode_forms
 description: A package for managing form state based on BLoC.
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/leancodepl/leancode_forms.git
 
 environment:


### PR DESCRIPTION
Changes required to upgrade flutter version in [template app](https://github.com/leancodepl/leancode_flutter_template), specifically upgrade of rxdart to 0.28.0 is needed 

Please let me know about the approach taken here. For now in [pr upgrading flutter in template](https://github.com/leancodepl/leancode_flutter_template/pull/340) i'm using ref from the last commit in this branch as dependency; previously it was imported as package. Should there be new release planned or should we stick to getting package from ref? If so am I allowed to merge it to main?  