### PR TITLE
Added an example with autoValidation + subscribeToFields combo

### DIFF
--- a/example/lib/screens/password_form.dart
+++ b/example/lib/screens/password_form.dart
@@ -120,9 +120,14 @@ class PasswordFormController extends AdvancedFormController {
     lowerCaseRequired: true,
   );
 
+  // `subscribeToFields` + `autoValidate: true
+  // we expect: no validation fires until one of the
+  // subscribed fields' VALUE actually changes (state-only changes like the
   late final repeatPassword = AdvancedTextFieldController<ValidationError>(
     validator: passwordMatch(password, ValidationError.doesNotMatch),
-  )..subscribeToFields([switchField, password]);
+  )
+    ..setAutovalidate(true)
+    ..subscribeToFields([switchField, password]);
 
   void submit() {
     if (validate()) {

--- a/example/lib/screens/password_form.dart
+++ b/example/lib/screens/password_form.dart
@@ -120,9 +120,9 @@ class PasswordFormController extends AdvancedFormController {
     lowerCaseRequired: true,
   );
 
-  // `subscribeToFields` + `autoValidate: true
-  // we expect: no validation fires until one of the
-  // subscribed fields' VALUE actually changes (state-only changes like the
+  // `subscribeToFields` + `autovalidate: true`:
+  // We expect: no validation fires until one of the subscribed fields' value
+  // actually changes (state-only changes, like status updates, are ignored).
   late final repeatPassword = AdvancedTextFieldController<ValidationError>(
     validator: passwordMatch(password, ValidationError.doesNotMatch),
   )


### PR DESCRIPTION
Testing [LMG-396]( https://leancode.atlassian.net/browse/LMG-396):

Can't reproduce. It looks like the issue was resolved earlier, or resolved itself after migrating to ValueNotifier.

I added a few demo lines that use this combo, we can include this in our set of examples.

[LMG-396]: https://leancode.atlassian.net/browse/LMG-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ