### PR TITLE
ci: fix test workflow — deprecated actions/cache@v2 and EquatableMixin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,23 +20,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
-          channel: ${{ matrix.channel }}
           flutter-version: ${{ matrix.version }}
+          cache: true
 
       - name: Flutter version
         run: flutter --version
-
-      - name: Cache pub dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.FLUTTER_HOME }}/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: ${{ runner.os }}-pub-
 
       - name: Download pub dependencies
         run: flutter pub get

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -202,10 +202,10 @@ packages:
     dependency: transitive
     description:
       name: equatable
-      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/field/cubit/field_cubit.dart
+++ b/lib/src/field/cubit/field_cubit.dart
@@ -280,7 +280,7 @@ enum FieldStatus {
 }
 
 /// The state of a [FieldCubit].
-class FieldState<T, E extends Object> with EquatableMixin {
+class FieldState<T, E extends Object> with Equatable {
   /// Creates a new [FieldState].
   const FieldState({
     required this.value,

--- a/lib/src/form_group_cubit/form_group_cubit.dart
+++ b/lib/src/form_group_cubit/form_group_cubit.dart
@@ -318,7 +318,7 @@ class FormGroupCubit extends Cubit<FormGroupState> with Disposable {
 }
 
 /// The state of a [FormGroupCubit].
-class FormGroupState with EquatableMixin {
+class FormGroupState with Equatable {
   /// Creates a new [FormGroupState].
   const FormGroupState({
     this.wasModified = false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.17.1
-  equatable: ^2.0.5
+  equatable: ^2.1.0
   flutter:
     sdk: flutter
   flutter_bloc: ^9.0.0


### PR DESCRIPTION
Makes the `test` workflow green again. It was failing on two independent problems, one hiding the other.

## 1. The workflow could not start — deprecated `actions/cache@v2`

The `test` workflow has failed on every branch and PR since at least June 23. The job died in ~4 s during action resolution, before a single step ran:

```
##[error]This request has been automatically failed because it uses a deprecated
version of `actions/cache: v2`. Please update your workflow to use v3/v4 of
actions/cache to avoid interruptions.
```

GitHub now force-fails any job that resolves `actions/cache@v1` or `@v2`. Our `Cache pub dependencies` step pinned `actions/cache@v2`, so the whole job was rejected up front. No analyzer or test output was ever produced — the red check said nothing about the code.

Affected runs include `refactor/forms-rework` (#52), `skill/leancode-forms`, and `fix/LMG-396-validate-after-field-subscription-fix`.

### Fix

Rather than bump the pin to `actions/cache@v4`, the manual cache step is removed entirely. `subosito/flutter-action@v2` caches the Flutter SDK and the pub cache itself via `cache: true`. The `publish` workflow already uses exactly this and works, so this aligns the two workflows.

The old step was also fragile on its own terms: it cached `${{ env.FLUTTER_HOME }}/.pub-cache`, a path that depended on `flutter-action@v1` internals, and it keyed only on `pubspec.lock` while never caching the SDK.

Alongside that:

- `subosito/flutter-action` `v1` → `v2`. `v1` is unmaintained and is what tied us to the manual cache step.
- Dropped the `channel:` input. The matrix never set `matrix.channel`, so it always resolved to an empty string.
- `actions/checkout` `v3` → `v4` in both workflows, so checkout is not the next action to be force-failed.

The check name is unchanged (`Flutter 3.29.x`), so branch protection rules keep matching.

## 2. `flutter analyze` failed — deprecated `EquatableMixin`

With the workflow running again, the job got as far as the analyzer and failed there:

```
info • 'EquatableMixin' is deprecated and shouldn't be used. use Equatable as a mixin instead
      • lib/src/field/cubit/field_cubit.dart:283:44 • deprecated_member_use
info • 'EquatableMixin' is deprecated and shouldn't be used. use Equatable as a mixin instead
      • lib/src/form_group_cubit/form_group_cubit.dart:321:27 • deprecated_member_use
2 issues found.
```

`flutter analyze` exits non-zero on infos, so these two lines failed the build.

### Fix

equatable 2.1.0 turned `Equatable` into an `abstract mixin class` and deprecated `EquatableMixin`. `FieldState` and `FormGroupState` now mix in `Equatable` directly. Both keep their `const` constructors, because `Equatable` declares `const Equatable()`.

This requires a constraint bump, `equatable: ^2.0.5` → `^2.1.0`. In 2.0.8 `Equatable` is still a plain `abstract class` and cannot be mixed in, so the old constraint would let a consumer resolve a version where this code does not compile.

## Verification

Run locally against Flutter 3.29.0 via fvm, matching the CI version:

- `flutter analyze` — `No issues found!`
- `flutter test` — 69 passed

CI on the first commit of this PR already confirms half of it: the job went from 4 s (rejected at resolution) to 1 m 3 s, reaching the analyzer.

## Note for the reviewer

This bumps a dependency constraint on a published package but does not touch `version:` or `CHANGELOG.md`. The repo records dependency bumps in the changelog (`Bumped `bloc` to `^9.0.0`.`), so an entry is probably wanted — I left the release numbering alone since the ChangeNotifier rewrite in #52 is in flight and will drive the next version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
