### PR TITLE
Add mustBeTrue validator for boolean fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Flutter form validation and state management without a framework on top. `advanced_forms` gives you typed field controllers, composable sync and async validation, and form-level state tracking, built on `ChangeNotifier` and `ValueListenable`.
 
 - **Typed field controllers** — text fields, checkboxes and switches, dropdowns and radio groups, and multi-select fields, each with its own value type *and* its own error type.
-- **Validators that compose** — `filled`, `notEmpty`, `notNull`, `isTrue`, `atLeastLength`, `notLongerThan`, `exactly` and numeric checks, combined with `&` and `|`, or any `E? Function(T)` you write yourself.
+- **Validators that compose** — `filled`, `notEmpty`, `notNull`, `mustBeTrue`, `atLeastLength`, `notLongerThan`, `exactly` and numeric checks, combined with `&` and `|`, or any `E? Function(T)` you write yourself.
 - **Async validation** — debounced server-side checks ("is this email taken?") with a timeout, failure handling and cached answers.
 - **Cross-field validation** — re-run a validator when the fields it depends on change, or derive one field's value from another.
 - **Validation modes** — validate on submit, on every keystroke, or on unfocus. Set once, applied to the whole form.
@@ -240,7 +240,7 @@ Note that `valid` means *no error recorded*, not *checked and passed*: a field n
 
 ### Ready-to-use validators
 
-- `filled`, `notEmpty`, `notNull`, `isTrue` — reject empty strings (whitespace-only included), empty lists, nulls, and `false`,
+- `filled`, `notEmpty`, `notNull`, `mustBeTrue` — reject empty strings (whitespace-only included), empty lists, nulls, and `false`,
 - `notLongerThan`, `atLeastLength`, `exactly`, `nothing` — string length bounds, an exact match, and "must be empty",
 - `positiveInteger`, `nonNegativeInteger`, `boundedNonNegativeInteger`, `positiveDecimal`, `nonNegativeDecimal` — numeric strings,
 - `and` / `or` (also `&` and `|`), `conditionalValidator`, `dynamicValidator` — combine two validators, run one only while a condition holds, or rebuild one on each run for parameters that change at runtime.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ Note that `valid` means *no error recorded*, not *checked and passed*: a field n
 
 ### Ready-to-use validators
 
-- `filled`, `notEmpty`, `notNull`, `mustBeTrue` — reject empty strings (whitespace-only included), empty lists, nulls, and `false`,
+- `filled`, `notEmpty`, `notNull` — reject empty strings (whitespace-only included), empty lists, and nulls,
+- `mustBeTrue` — reject `false` and null,
 - `notLongerThan`, `atLeastLength`, `exactly`, `nothing` — string length bounds, an exact match, and "must be empty",
 - `positiveInteger`, `nonNegativeInteger`, `boundedNonNegativeInteger`, `positiveDecimal`, `nonNegativeDecimal` — numeric strings,
 - `and` / `or` (also `&` and `|`), `conditionalValidator`, `dynamicValidator` — combine two validators, run one only while a condition holds, or rebuild one on each run for parameters that change at runtime.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Flutter form validation and state management without a framework on top. `advanced_forms` gives you typed field controllers, composable sync and async validation, and form-level state tracking, built on `ChangeNotifier` and `ValueListenable`.
 
 - **Typed field controllers** — text fields, checkboxes and switches, dropdowns and radio groups, and multi-select fields, each with its own value type *and* its own error type.
-- **Validators that compose** — `filled`, `notEmpty`, `notNull`, `atLeastLength`, `notLongerThan`, `exactly` and numeric checks, combined with `&` and `|`, or any `E? Function(T)` you write yourself.
+- **Validators that compose** — `filled`, `notEmpty`, `notNull`, `isTrue`, `atLeastLength`, `notLongerThan`, `exactly` and numeric checks, combined with `&` and `|`, or any `E? Function(T)` you write yourself.
 - **Async validation** — debounced server-side checks ("is this email taken?") with a timeout, failure handling and cached answers.
 - **Cross-field validation** — re-run a validator when the fields it depends on change, or derive one field's value from another.
 - **Validation modes** — validate on submit, on every keystroke, or on unfocus. Set once, applied to the whole form.
@@ -240,7 +240,7 @@ Note that `valid` means *no error recorded*, not *checked and passed*: a field n
 
 ### Ready-to-use validators
 
-- `filled`, `notEmpty`, `notNull` — reject empty strings (whitespace-only included), empty lists, and nulls,
+- `filled`, `notEmpty`, `notNull`, `isTrue` — reject empty strings (whitespace-only included), empty lists, nulls, and `false`,
 - `notLongerThan`, `atLeastLength`, `exactly`, `nothing` — string length bounds, an exact match, and "must be empty",
 - `positiveInteger`, `nonNegativeInteger`, `boundedNonNegativeInteger`, `positiveDecimal`, `nonNegativeDecimal` — numeric strings,
 - `and` / `or` (also `&` and `|`), `conditionalValidator`, `dynamicValidator` — combine two validators, run one only while a condition holds, or rebuild one on each run for parameters that change at runtime.

--- a/example/lib/screens/step_form.dart
+++ b/example/lib/screens/step_form.dart
@@ -552,7 +552,7 @@ class InvoiceStepController extends WizardStepController {
   );
 }
 
-/// Step 4. Terms acceptance uses [isTrue] so the switch must be on to proceed.
+/// Step 4. Terms acceptance uses [mustBeTrue] so the switch must be on to proceed.
 class ConfirmStepController extends WizardStepController {
   ConfirmStepController() {
     registerFields([newsletter, acceptTerms]);
@@ -564,7 +564,7 @@ class ConfirmStepController extends WizardStepController {
   final newsletter = AdvancedBooleanFieldController<ValidationError>();
 
   final acceptTerms = AdvancedBooleanFieldController<ValidationError>(
-    validator: isTrue(ValidationError.mustAccept),
+    validator: mustBeTrue(ValidationError.mustAccept),
   );
 }
 

--- a/example/lib/screens/step_form.dart
+++ b/example/lib/screens/step_form.dart
@@ -552,8 +552,7 @@ class InvoiceStepController extends WizardStepController {
   );
 }
 
-/// Step 4. A boolean field has no built-in validator, so the rule is a one-line
-/// closure.
+/// Step 4. Terms acceptance uses [isTrue] so the switch must be on to proceed.
 class ConfirmStepController extends WizardStepController {
   ConfirmStepController() {
     registerFields([newsletter, acceptTerms]);
@@ -565,7 +564,7 @@ class ConfirmStepController extends WizardStepController {
   final newsletter = AdvancedBooleanFieldController<ValidationError>();
 
   final acceptTerms = AdvancedBooleanFieldController<ValidationError>(
-    validator: (value) => value ? null : ValidationError.mustAccept,
+    validator: isTrue(ValidationError.mustAccept),
   );
 }
 

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -202,6 +202,15 @@ Validator<T?, E> notNull<T, E extends Object>(E message) => (value) {
       return null;
     };
 
+/// Rejects null and false.
+Validator<bool?, E> isTrue<E extends Object>(E message) => (value) {
+      if (value != true) {
+        return message;
+      }
+
+      return null;
+    };
+
 /// Rejects null and empty lists
 Validator<List<T>?, E> notEmpty<T, E extends Object>(E message) => (value) {
       if (value?.isEmpty ?? true) {

--- a/lib/src/validators/validators.dart
+++ b/lib/src/validators/validators.dart
@@ -203,7 +203,7 @@ Validator<T?, E> notNull<T, E extends Object>(E message) => (value) {
     };
 
 /// Rejects null and false.
-Validator<bool?, E> isTrue<E extends Object>(E message) => (value) {
+Validator<bool?, E> mustBeTrue<E extends Object>(E message) => (value) {
       if (value != true) {
         return message;
       }

--- a/skills/advanced_forms/SKILL.md
+++ b/skills/advanced_forms/SKILL.md
@@ -244,13 +244,14 @@ Every string validator is typed `Validator<String?, E>`, even though `AdvancedTe
 | `boundedNonNegativeInteger(max, e)` | `String?` | anything but `0..max` or the literal string `>max` |
 | `notNull(e)` | `T?` (any) | null |
 | `notEmpty(e)` | `List<T>?` | null, empty list |
+| `isTrue(e)` | `bool?` | null, false |
 
 `conditionalValidator(v, () => enabled)` runs `v` only while the getter returns true; `dynamicValidator(() => buildValidator())` rebuilds the validator on each call. Both keep `T`.
 
-**There is no bool validator, and `notEmpty` does not fit a `Set`.** Write a closure:
+**`notEmpty` does not fit a `Set`.** Write a closure:
 
 ```dart
-validator: (value) => value ? null : MyError.mustAccept,        // bool field
+validator: isTrue(MyError.mustAccept),                          // bool field
 validator: (value) => value.isEmpty ? MyError.pickOne : null,   // Set<V> field
 ```
 

--- a/skills/advanced_forms/SKILL.md
+++ b/skills/advanced_forms/SKILL.md
@@ -244,14 +244,14 @@ Every string validator is typed `Validator<String?, E>`, even though `AdvancedTe
 | `boundedNonNegativeInteger(max, e)` | `String?` | anything but `0..max` or the literal string `>max` |
 | `notNull(e)` | `T?` (any) | null |
 | `notEmpty(e)` | `List<T>?` | null, empty list |
-| `isTrue(e)` | `bool?` | null, false |
+| `mustBeTrue(e)` | `bool?` | null, false |
 
 `conditionalValidator(v, () => enabled)` runs `v` only while the getter returns true; `dynamicValidator(() => buildValidator())` rebuilds the validator on each call. Both keep `T`.
 
 **`notEmpty` does not fit a `Set`.** Write a closure:
 
 ```dart
-validator: isTrue(MyError.mustAccept),                          // bool field
+validator: mustBeTrue(MyError.mustAccept),                      // bool field
 validator: (value) => value.isEmpty ? MyError.pickOne : null,   // Set<V> field
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a built-in `mustBeTrue` validator that rejects `null` and `false`, so checkbox and switch fields can require an accepted/on value without a one-line closure.

```dart
final acceptTerms = AdvancedBooleanFieldController(
  validator: mustBeTrue(MyError.mustAccept),
);
```

Named `mustBeTrue` rather than `isTrue` so it does not collide with the `isTrue` matcher from `flutter_test`.

The Confirm step in the example wizard now uses it. README lists `mustBeTrue` as its own ready-to-use validator, and the agent skill includes it in the built-in table.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e510fe6-93c1-460d-9c60-e9d1ef51a110?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e510fe6-93c1-460d-9c60-e9d1ef51a110&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

