### PR TITLE
ci: add a pana score check and widen the PR trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,22 @@ jobs:
       - name: Dry run pub publish
         # We don't want it to fail the CI, it's just to see how would `pub publish` behave.
         run: dart pub publish --dry-run || true
+
+  pana-score:
+    name: pana score
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Score with pana
+        continue-on-error: true
+        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
+        with:
+          path: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
     tags-ignore: ['v*']
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
Two CI changes, both in `.github/workflows/test.yml`.

## pana score check

Adds a `pana-score` job that scores the package with [pana](https://pub.dev/packages/pana) via the shared `leancodepl/mobile-tools/.github/actions/pana-score` action, mirroring the setup in [`leancode_lint-test.yml`](https://github.com/leancodepl/flutter_corelibrary/blob/master/.github/workflows/leancode_lint-test.yml).

```yaml
  pana-score:
    name: pana score
    runs-on: ubuntu-latest
    permissions:
      contents: read
      statuses: write
    steps:
      - name: Checkout
        uses: actions/checkout@v4
      - name: Score with pana
        continue-on-error: true
        uses: leancodepl/mobile-tools/.github/actions/pana-score@e9f138c252f8e2254c88273367958fcc6bb39cad # pana-score-v1.3
        with:
          path: .
```

Notes on the choices:

- **`path: .`** — unlike flutter_corelibrary, which is a monorepo and points at `packages/leancode_lint`, this repo is a single package at the root.
- **Pinned to `pana-score-v1.3`** — the same SHA the corelibrary workflow uses, and the newest tag of that action.
- **`continue-on-error: true`** — matches the reference. A below-100 score won't turn CI red; it surfaces as a `pana (advanced_forms)` commit status plus a job summary breaking down the deductions. The action still hard-fails if pana produces no parseable score at all.
- **Separate job, not a step in `test`** — again per the reference. It runs in parallel and scores against stable Dart/Flutter rather than the matrix's pinned 3.29.x. The action detects `sdk: flutter` in `pubspec.yaml` and sets up Flutter instead of plain Dart, so this package is handled correctly.
- **`actions/checkout@v4`** — kept the repo's existing unpinned style rather than the corelibrary's SHA pin, so the file stays internally consistent with the `test` job above it.

## Run tests on PRs targeting any branch

```yaml
on:
  push:
    branches: [ main ]
    tags-ignore: ['v*']
  pull_request:
```

The `branches:` filter is dropped entirely rather than replaced with a wildcard — a bare `pull_request:` matches every base branch, and the default activity types (`opened`, `synchronize`, `reopened`) are unchanged. This means PRs into long-lived feature branches get tested too.

The `push` trigger is deliberately left on `main` only: widening it as well would mean every branch push builds *and* its PR builds, double-running each commit.

Both jobs pick this up, since the trigger is workflow-level.

## Verification

The YAML was checked to parse and to produce the two expected jobs with the intended trigger config. The pana job itself hasn't run yet — this PR's own CI is the first real exercise of it, so the resulting score is worth a look before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6fJEv1yxs39ofrMSzVCTg)_