### PR TITLE
Fix AdvancedFormState.allFields throwing when a subform's fields are explicitly typed

### DIFF
--- a/lib/src/form/advanced_form_state.dart
+++ b/lib/src/form/advanced_form_state.dart
@@ -42,8 +42,12 @@ class AdvancedFormState with Equatable {
   final ValidationMode validationMode;
 
   /// This form's fields including every subform's fields.
-  Iterable<AdvancedFieldController<dynamic, dynamic>> get allFields =>
-      fields.followedBy(subforms.expand((e) => e.value.allFields));
+  Iterable<AdvancedFieldController<dynamic, dynamic>> get allFields sync* {
+    yield* fields;
+    for (final subform in subforms) {
+      yield* subform.value.allFields;
+    }
+  }
 
   // Fields that count — disabled subtrees excluded, matching what validate()
   // checks, so validate() and canSubmit always agree.

--- a/lib/src/form/advanced_form_state.dart
+++ b/lib/src/form/advanced_form_state.dart
@@ -42,6 +42,8 @@ class AdvancedFormState with Equatable {
   final ValidationMode validationMode;
 
   /// This form's fields including every subform's fields.
+  // `followedBy` compares element types at runtime and throws when a subform's
+  // field list was written out with an explicit type. A generator doesn't.
   Iterable<AdvancedFieldController<dynamic, dynamic>> get allFields sync* {
     yield* fields;
     for (final subform in subforms) {

--- a/test/src/form/form_controller_test.dart
+++ b/test/src/form/form_controller_test.dart
@@ -107,6 +107,45 @@ void main() {
       });
     });
 
+    group('allFields', () {
+      test('walks own fields and then every subform, recursively', () {
+        final nested = AdvancedFormController();
+        final nestedField = AdvancedFieldController<int, _Error2>(
+          initialValue: _initialValue2,
+        );
+        nested.registerFields([nestedField]);
+        subform
+          ..registerFields([subformField])
+          ..addSubform(nested);
+        form
+          ..registerFields([field1, field2])
+          ..addSubform(subform);
+
+        expect(
+          form.value.allFields,
+          [field1, field2, subformField, nestedField],
+        );
+        form.dispose();
+      });
+
+      test('walks a subform whose fields were registered as a typed list', () {
+        // A caller that spells the list out as
+        // `<AdvancedFieldController<dynamic, dynamic>>[...]` — as the skill's
+        // examples do — used to make this getter throw at runtime.
+        subform.registerFields(
+          <AdvancedFieldController<dynamic, dynamic>>[subformField],
+        );
+        form
+          ..registerFields(
+            <AdvancedFieldController<dynamic, dynamic>>[field1, field2],
+          )
+          ..addSubform(subform);
+
+        expect(form.value.allFields, [field1, field2, subformField]);
+        form.dispose();
+      });
+    });
+
     group('wasModified', () {
       test('is false after register', () {
         final emissions = _record<AdvancedFormState>(form);


### PR DESCRIPTION
`AdvancedFormState.allFields` threw a `TypeError` instead of returning the fields
whenever a form had a subform and either field list had been registered through an
explicitly typed literal:

```dart
registerFields(<AdvancedFieldController<dynamic, dynamic>>[email, password]);
```

```
type 'ExpandIterable<AdvancedFormController, AdvancedFieldController<dynamic, dynamic>>'
is not a subtype of type 'Iterable<AdvancedFieldController<dynamic, Object>>' of 'other'
  package:advanced_forms/src/form/advanced_form_state.dart 46:14  AdvancedFormState.allFields
```

`AdvancedFieldController` declares `E extends Object`, so `dynamic` in the `E` position
reifies to its bound and the list's runtime type is
`List<AdvancedFieldController<dynamic, Object>>`. `followedBy` checks at runtime that
`other` carries the same element type, and `subforms.expand(...)` produces
`Iterable<AdvancedFieldController<dynamic, dynamic>>`. The two do not match.

## Why it matters

`allFields` is what you walk to focus the first invalid field after a failed submit, or
to apply a server's per-field errors. The crash therefore landed in the "submit did not
go through" path — exactly when the user is already having a bad time. The condition is
narrow but not exotic: a subform, plus one read of `allFields`.

## The fix

Yield the fields instead of concatenating them; `sync*` does no such check.
`_countedFields`, sitting immediately below in the same file and doing the same walk, was
already written this way, so `allFields` was the odd one out rather than a deliberate
choice.

## Tests

Two added to `test/src/form/form_controller_test.dart`: one pinning the documented order
(own fields, then each subform's, recursively), one reproducing the crash. The second
fails without the fix.

No API change.